### PR TITLE
feat(ocean GCP/launchspec): Added support for LocalNvmeSsdCount and LocalSsdEphemeralStorageCount under Storage Object.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "spotinst_ocean_gke_launch_spec" "launchspec" {
   dynamic "metadata" {
     for_each = var.metadata == null ? [] : var.metadata
     content {
-      key   = metadata.key["key"]
+      key   = metadata.value["key"]
       value = metadata.value["value"]
     }
   }
@@ -77,9 +77,16 @@ resource "spotinst_ocean_gke_launch_spec" "launchspec" {
   }
 
   dynamic "storage" {
-    for_each = var.local_ssd_count != null ? [1] : []
+    for_each = (
+    var.local_ssd_count != null ||
+    var.local_nvme_ssd_count != null ||
+    var.local_ssd_ephemeral_storage_count != null
+    ) ? [1] : []
+
     content {
-      local_ssd_count = var.local_ssd_count
+      local_ssd_count                    = var.local_ssd_count
+      local_nvme_ssd_count               = var.local_nvme_ssd_count
+      local_ssd_ephemeral_storage_count  = var.local_ssd_ephemeral_storage_count
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,17 @@ variable "local_ssd_count" {
   description = "Defines the number of local SSDs to be attached per node for this VNG."
   default     = null
 }
+variable "local_nvme_ssd_count" {
+  type        = number
+  description = "Defines the number of local NVMe SSDs to be attached per node in raw block mode for this VNG. All instance_types configured in this VNG must support the value of local_nvme_ssd_count. Otherwise, if the Ocean cluster has instance_types on a permit list, at least one must support the value of local_nvme_ssd_count."
+  default     = null
+}
+
+variable "local_ssd_ephemeral_storage_count" {
+  type        = number
+  description = "Defines the number of local SSDs to be used as ephemeral storage per node for this VNG. All instance_types configured in this VNG must support the value of local_ssd_ephemeral_storage_count. Otherwise, if the Ocean cluster has instance_types on a permit list, at least one must support the value of local_ssd_ephemeral_storage_count."
+  default     = null
+}
 variable "max_instance_count" {
   type        = number
   description = "Option to set a maximum number of instances per virtual node group. Can be null. If set, the value must be greater than or equal to 0."


### PR DESCRIPTION
Added support for LocalNvmeSsdCount and LocalSsdEphemeralStorageCount under Storage Object.

https://flexera.atlassian.net/browse/SPTAUT-19589